### PR TITLE
fix design apply status from 0 to non zero if a file path is invalid

### DIFF
--- a/mesheryctl/internal/cli/root/design/apply.go
+++ b/mesheryctl/internal/cli/root/design/apply.go
@@ -118,8 +118,7 @@ mesheryctl design apply [design-name]
 			if !validURL {
 				content, err := os.ReadFile(file)
 				if err != nil {
-					utils.Log.Error(utils.ErrFileRead(errors.Errorf("file path %s is invalid. Enter a valid path ", file)))
-					return nil
+					return errors.Wrap(err, fmt.Sprintf("file path %s is invalid. Enter a valid path", file))
 				}
 
 				// if --skip-save is not passed we save the pattern first


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #
[mesheryctl] design apply command returns status 0 despite of invalid path #14186
**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
